### PR TITLE
Apply race condition fix to mux (#78)

### DIFF
--- a/topic_tools/src/mux_node.cpp
+++ b/topic_tools/src/mux_node.cpp
@@ -64,6 +64,10 @@ void MuxNode::make_subscribe_unsubscribe_decisions()
 
 void MuxNode::process_message(std::shared_ptr<rclcpp::SerializedMessage> msg)
 {
+  std::scoped_lock lock(pub_mutex_);
+  if (!pub_) {
+    return;
+  }
   pub_->publish(*msg);
 }
 


### PR DESCRIPTION
Apply fix described in https://github.com/ros-tooling/topic_tools/pull/56 to mux_node

backport of https://github.com/ros-tooling/topic_tools/pull/78